### PR TITLE
grpc: update grpc import path to grpc.go4.org

### DIFF
--- a/grpc/grpc.go
+++ b/grpc/grpc.go
@@ -54,7 +54,7 @@ const generatedCodeVersion = 4
 // relative to the import_prefix of the generator.Generator.
 const (
 	contextPkgPath = "context"
-	grpcPkgPath    = "go4.org/grpc"
+	grpcPkgPath    = "grpc.go4.org"
 )
 
 func init() {


### PR DESCRIPTION
Follow-up to e3bfbf05195545d0ff35e705edb9e007dd61ed46. It missed one instance.

Updates go4org/go4#30